### PR TITLE
Initial commit of centralized contrib / code of conduct

### DIFF
--- a/get-involved/code-of-conduct.md
+++ b/get-involved/code-of-conduct.md
@@ -1,2 +1,131 @@
 # Code of Conduct
 
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at (see contact links): `michael [PERIOD] e [PERIOD] gangl [AT] jpl [PERIOD] nasa [PERIOD] gov`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/get-involved/contributing-guide.md
+++ b/get-involved/contributing-guide.md
@@ -1,2 +1,301 @@
-# Contributing Guide
+# Contributing to Unity
 
+Thanks for taking the time to consider contributing! We very much appreciate your time and effort. This document outlines the many ways you can contribute to our project, and provides detailed guidance on best practices. We look forward to your help!
+
+## Prerequisites
+
+Before you begin contributing to our project, it'll be a good idea to ensure you've satisfied the below pre-requisites. 
+
+### Developer Certificate of Origin (DCO)
+
+To accept your contributions for any kind of patch, you'll want to:
+1. Understand what a Developer Certificate of Origin is. See [this](https://wiki.linuxfoundation.org/dco) guide.
+2. Read and agree to the [terms](https://developercertificate.org) of the Developer Certificate of Origin.
+3. Remember to add your Sign-Off for each patch contribution you submit to our project via either:
+   1. By using the `-s` flag if using Git. See [these](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) instructions.
+   2. By including the following text in your patch contributions (i.e. pull requests)
+   ```
+   Signed-off-by: Full Name <email>
+   ``` 
+
+Reviewers reviewing your patch will look for the sign-off before deciding to accept your contribution.
+
+### License
+
+Our project has our licensing terms, including rules governing redistribution, documented in each of our repositories' `LICENSE` file. Please take a look at that file and ensure you understand the terms. This will impact how we, or others, use your contributions.
+
+### Code of Conduct
+
+Our Code of Conduct helps facilitate a positive interaction environment for everyone involved with the team, and provides guidance on what to do if you experience problematic behavior. Read more in our [Code of Conduct](https://unity-sds.gitbook.io/about/get-involved/code-of-conduct), and make sure you agree to its terms. 
+
+### Developer Environment
+
+For more detailed guides, see our each of our developer areas in our [main docs site](https://unity-sds.gitbook.io/about/) for more details on how to set up your local environment, to best contribute to our project. 
+
+At a minimum however to submit patches (if using Git), you'll want to ensure you have:
+1. An account on the Version Control System our project uses (i.e. GitHub).
+2. The Version Control System client (i.e. Git) installed on your local machine.
+3. The ability to edit, build, and test our project on your local machine. Again, see our `README.md` or detailed developer guide for more details 
+
+### Communication Channels
+
+Before contributing changes to our project, it's a great idea to be familiar with our communication channels and to socialize your potential contributions to get feedback early. This will help give you context for your contributions, no matter their form.
+
+Our communication channels are:
+- **Issue tracking systems** - see our individual repos' "Issues" tab for a regularly monitored area to report issues with our software or propose changes
+- **Discussion board (if available)** - see our individual repos' "Discussions" tab for a permanently archived place to hold conversations related to our project, and to propose as well as show+tell topics to the contributor team. This resource can be searched for old discussions.
+
+## Our Development Process
+
+Our project integrates contributions from many people, and so we'd like to outline a process you can use to visualize how your contributions may be integrated if you provide something. 
+
+```mermaid
+flowchart TD
+    repo_proj[(One of our Repositories)]-->|Fork|repo_fork[(Your Forked Repository)]
+    repo_fork-->|Make|patch(Your Changes)
+    patch-->|Submit|pr(Pull Request)
+    pr==>|Approved|repo_proj
+    pr-->|Changes Requested|repo_fork
+```
+
+### Fork our Repositories
+
+Forking our repositories, as opposed to directly committing to a branch is the preferred way to propose changes. 
+
+See [this GitHub guide](https://docs.github.com/en/get-started/quickstart/fork-a-repo) on forking for information specific to GitHub.com
+
+#### Find or File an Issue
+
+Make sure people are aware you're working on a patch! Check out any of our repositories' "Issues" tab and find an open issue you'd like to work against, or alternatively file a new issue and mention you're working on a patch.
+
+#### Choose the Right Branch to Fork
+
+Our project typically has the following branches available in any given repository, make sure to fork either the default branch or a branch someone else already tagged with a particular issue ticket you're working with.
+- (default) `main`
+
+### Make your Modifications
+
+Within your local development environment, this is the stage at which you'll propose your changes, and commit those changes back to version control. See a given repository's `README.md` or development guide for more specifics on what you'll need as prerequisites to setup your local development environment.
+
+#### Commit Messages
+
+Commit messages to version control should reference a ticket in their title / summary line:
+
+```
+Issue #248 - Show an example commit message title
+```
+
+This makes sure that tickets are updated on GitHub with references to commits that are related to them.
+
+Commit should always be atomic. Keep solutions isolated whenever possible. Filler commits such as "clean up white space" or "fix typo" should be merged together before making a pull request, and significant sub-feature branches should be [rebased](https://www.youtube.com/results?search_query=git+rebase) to preserve commit history. Please ensure your commit history is clean and meaningful!
+
+Additionally, remember to "Sign-Off" on your commits to align with our [Developer Certificate of Origin (DCO) policy](#developer-certificate-of-origin-dco). 
+
+### Submit a Pull Request
+
+Pull requests are the core way our project will receive your patch contributions. Navigate to your branch on your own fork within the version control system, and submit a pull request or submit the patch text to our project. 
+
+Please make sure to provide a meaningful text description to your pull requests, whenever submitted. Use the following template:
+```
+## Purpose
+- Clear, easy-to-understand sentences outlining the purpose of the PR
+## Proposed Changes
+- [ADD] ...
+- [CHANGE] ...
+- [FIX] ...
+## Issues
+- Links to relevant issues
+- Example: issue-XYZ
+## Testing
+- Provide some proof you've tested your changes 
+- Example: test results available at ...
+- Example: tested on operating system ...
+```
+
+**Working on your first Pull Request?** See guide: [How to Contribute to an Open Source Project on GitHub](https://kcd.im/pull-request)
+
+### Reviewing your Pull Request
+
+Reviewing pull-requests, or any kinds of proposed patch changes, is an art. That being said, we follow the following best practices:
+- **Intent** - is the purpose of your pull-request clearly stated?
+- **Solution** - is your pull-request doing what you want it to?
+- **Correctness** - is your pull-request doing what you want it to *correctly*?
+- **Small Patches** - is your patch of a level of complexity and brevity that it can actually be reviewed by a human being? Or is does it involve too much content for one pull request?
+- **Coding best practices** - are you following best practices in the coding / contribution language being used?
+- **Readability** - is your patch readable, and ultimately maintainable, by others?
+- **Reproducibility** - is your patch reproducible by others?
+- **Tests** - do you have or have conducted meaningful tests?
+
+## Ways to Contribute
+
+### ⚠️ Issue Tickets
+
+> *Do you like to talk about new diagrams, changes to existing ones, or requests?*
+
+Issue tickets are a very simple way to get involved in our project. It also helps new contributors get an understanding of the project more comprehensively. This is a great place to get started with the project if you're not sure where to start. 
+
+See our list of issues at: any of our repositories' "Issues" tab
+
+#### Cleaning up Duplicate Issues
+
+Often we receive duplicate issues that can confuse project members on *which* issue ticket to hold conversations upon.
+
+Here's how you can help:
+1. Scan the list of *open* issue tickets for duplicate titles, or internal wording 
+2. If you find duplicates, copy / paste the below message on the conversation thread of the issue ticket *that has less participants* involved
+
+```
+This is a duplicate issue. Please migrate conversations over to [issue-XYZ](hyperlink to issue)
+```
+
+#### Good First Issues
+
+Issue tickets can vary in complexity, and issues labeled with `good first issue` labels are often a great way to get started with the project as a newcomer. 
+
+Take a look at our any of our repositories' "Issues" tab, and filter by `good first issue` for issues that are low-complexity, and that will help you get familiar with our issue tracking and patch submission process.
+
+#### Suggesting New Issue Labels
+
+Labels within our any of our repositories' "Issues" tab are a great way to quickly sort through tickets. The project may not yet have labels to cover the full variety of issue tickets. Take a look through a list of issues, and if you notice a set of issue tickets that seem similar but are not categorized with an existing label, go ahead submit a request within one of the issues you've looked at with the following text:
+
+```
+I've noticed several other issues that are of the same category as this issue. Shall we make a new label for these types of issues?
+```
+
+#### Submitting Bug Issues
+
+Resolving bugs is a priority for our project. We welcome bug reports. However, please make sure to do the following prior to submitting a bug report:
+- **Check for duplicates** - there may be a bug report already describing your issue, so check the any of our repositories' "Issues" tab first
+
+Here's some guidance on submitting a bug issue:
+1. Navigate to our any of our repositories' "Issues" tab and file a new issue
+2. Select a bug template (if available) for your issue
+   1. Fill out the template fields to the best of your ability, including output snippets or screenshots where applicable
+3. Follow the general guidelines below for extra information about your bug
+   1. Include a code snippet if you have it showcasing the bug
+   2. Provide reproducible steps of how to recreate the bug
+   3. If the bug triggers an exception or error message, include the *full message* or *stacktrace*
+   4. Provide information about your operating system and the version of our project you're using
+
+#### Submitting New Feature Issues
+
+We welcome new feature requests to help grow our project. However, please make sure to do the following prior to submitting a bug report:
+- **Check for duplicates** - there may be a new feature issue already describing your issue, so check the any of our repositories' "Issues" tab first
+- **Consider alternatives** - is your feature / diagram really needed? Or is there a feature within our project or with a third-party that may help you achieve what you want?
+
+Here's some guidance on submitting a new feature issue:
+1. Navigate to our any of our repositories' "Issues" tab and file a new issue
+2. Select a new feature template (if available) for your issue
+   1. Fill out the template fields to the best of your ability
+
+#### Submitting Security Vulnerability Issues
+
+Security vulnerabilities should **not** be filed to the regular issue tracking system.
+
+Report your security vulnerabilities to: `michael [PERIOD] e [PERIOD] gangl [AT] jpl [PERIOD] nasa [PERIOD] gov`
+
+Please be sure to:
+* Indicate the severity of the vulnerability
+* Provide any workarounds, if you know them
+* Provide return-contact information to follow-up with you if needed
+
+#### Reviewing Pull Requests
+
+Reviewing others' contributions is a great way to learn about best practices in both contributions as well as software. 
+
+Take a look at our any of our repos' Pull Request tabs, and try the following options for providing a review:
+1. Read the code / patch associated with the pull-request, and take note of any coding, bug, or documentation issues if found
+2. Try to recreate the pull-request patch on your local machine, and report if it has issues with your system in particular
+3. Scan over suggested feedback from other contributors, and provide feedback if necessary
+
+### 📖 Documentation 
+
+Documentation is the core way our users and contributors learn about the project. We place a high value on the quality, thoroughness, and readability of our documentation. Writing or editing documentation is an excellent way to contribute to our project without performing active coding. 
+
+⚠️ It's **highly** advised that you take a look at our any of our repositories' "Issues" tab before considering any documentation contributions. Here's some guidelines:
+1. Check if any duplicate issues exist that cover your documentation contribution idea / task, and add comments to those tickets with your thoughts.
+2. If no duplicates exist, create a new issue ticket and get a conversation started before making documentation changes.
+
+Some guidelines for documentation best practices (summarized from Google's [excellent documentation guide](https://google.github.io/styleguide/docguide/best_practices.html)):
+- **Minimum viable docs** - don't do less documentation than your users / developers need, but also don't do more
+- **Changed code = changed docs** - if your code has changed, remember to update your documentation
+- **Delete old docs** - continually clean your documentation tree, and remove outdated docs regularly
+
+#### Documentation Organization
+
+The overall structure of our project documentation is detailed on: 
+- https://unity-sds.gitbook.io/about/
+- Located within the repository: https://github.com/unity-sds/unity-docs 
+
+The overall structure of our project documentation within a given repository is typically as follows:
+- Source-controlled documentation
+  - README.md - top-level information about how to run, build, and contribute to the project
+  - CODE_OF_CONDUCT.md) - best practices and guidance on how to work well with other people in the project, and suggestions on dealing with interpersonal issues
+  - CONTRIBUTING.md - guidance on contributing to the project
+  - LICENSE - end-user license for our intellectual property
+
+For directions on contributing to our source-controlled documentation:
+1. Ensure you have development [prerequisites](#prerequisites) cleared.
+2. Have your [development environment](#developer-environment) set up properly.
+3. Go through our [development process](#our-development-process), including proposing changes to our project.
+
+#### Writing Style
+
+To ensure documentation is readable and consistent by newcomers and experts alike, here are some suggestions on writing style for English:
+- Use gender neutral pronouns (they/their/them) instead of he/she/his/her 
+- Avoid qualifiers that minimize the difficulty of a task at hand, e.g. avoid words like “easily”, “simply”, “just”, “merely”, “straightforward”, etc. Readers' expertise may not match your own, and qualifying complexity may deter some readers if the task does not match their level of experience. That being said, if a particular task is difficult or complex, do mention that. 
+
+#### Common Wording 
+
+Below are some commonly used words you'll want to leverage in your documentation contributions:
+- **GitHub** - one word, and capitalization of the 'G' and the 'H'
+
+#### Inline Code Documentation
+
+For language-specific guidance on code documentation, including style guides, see [Google's list of language style guides](https://google.github.io/styleguide/) for a variety of languages. 
+
+Additionally, take a look at Google's recommendations on [inline code documentation](https://google.github.io/styleguide/docguide/best_practices.html#documentation-is-the-story-of-your-code) for best practices. 
+
+#### Media
+
+Media, such as such as images, videos, sound files, etc., are an excellent way to explain documentation to a wider audience more easily. Include media in your contributions as often as possible.
+
+When including media into our version-control system, it is recommended to use formats such as:
+- Small, single-purpose diagrams: [Mermaid](https://mermaid-js.github.io/mermaid/#/) format
+- Architectural diagrams: [C4 model](https://c4model.com)
+- Images: JPEG/PNG format
+- Videos: H264 MPEG format
+- Sounds: MP3 format
+
+### ❓ Questions
+
+Answering questions is an excellent way to learn more about our project, as well as get better known in our project community. 
+
+Here are just a few ways you can help answer questions for our project:
+- Answer open questions in our discussion forum (if available)
+- Answer open questions mentioned in our any of our repositories' "Issues" tab
+
+When answering questions, keep the following in mind:
+- Be polite and friendly. See our [Code of Conduct](https://unity-sds.gitbook.io/about/get-involved/code-of-conduct) recommendations as you interact with others in the team.
+- Repeat the specific question you are answering, followed by your suggestion.
+- If suggesting code for diagrams, repeat the line of code that needs to be altered, followed by your alteration
+- Include any post-steps or checks to verify your answer can be reproduced 
+
+### 🎨 Design
+
+Design files can help to guide new features and new areas of expansion for our project. We welcome these kinds of contributions.
+
+Here are just a few ways you can help provide design recommendations for our project:
+- Create visual mockups or diagrams to before trying to contribute complex diagrams. These can be hand-drawn for ease of generation.
+- Create art, such as logos or icons, to support the user experience for the project
+
+Each of the above can be contributed directly to repository code, and you should use our [development process](#our-development-process) to contribute your additions.
+
+### 🎟️ Meetups
+
+A great way to contribute towards our project goals is to socialize and encourage people to meet and learn more about each other. Consider ideas like:
+- Propose workshops or meetups regarding some topic within our project
+- Help point project contributors and community members to conferences and publications where they may socialize their unique innovations
+- Schedule in-person or virtual happy-hours to help create a more social atmosphere within the project community
+
+For the above ideas, use our [communication channels](#communication-channels) to propose get-togethers.  

--- a/get-involved/contributing-guide.md
+++ b/get-involved/contributing-guide.md
@@ -1,4 +1,4 @@
-# Contributing to Unity
+# Contributing Guide
 
 Thanks for taking the time to consider contributing! We very much appreciate your time and effort. This document outlines the many ways you can contribute to our project, and provides detailed guidance on best practices. We look forward to your help!
 


### PR DESCRIPTION
## Purpose
- Have a centralized contributing guide as well as code of conduct that individual repos can point to
- These new files would be placed in: https://unity-sds.gitbook.io/about/get-involved
- NOTE: all repos with standalone Code of Conduct / Contributing Guide docs should be updated to reference these central docs instead
## Proposed Changes
- [ADD] Central contributing guide
- [ADD] Central code of conduct 
## Issues
- n/a
## Testing
- Markdown preview in GH live editor